### PR TITLE
🐛 integrate formatter with monaco, unbind editor

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -114,20 +114,6 @@ export const App: Component = () => {
     actions.set({ error: '' });
   };
 
-  formatter.addEventListener('message', ({ data }) => {
-    const { event, code } = data;
-
-    switch (event) {
-      case 'RESULT':
-        actions.setCurrentSource(code);
-        break;
-    }
-  });
-
-  const formatCode = (code: string) => {
-    formatter.postMessage({ event: 'FORMAT', code });
-  };
-
   /**
    * This whole block before the slice of view
    * is an experimental resizer, need to tidy this up
@@ -298,7 +284,7 @@ export const App: Component = () => {
           disabled={!store.interactive}
           canCopy
           canFormat
-          onFormat={formatCode}
+          formatter={formatter}
           isDark={store.dark}
           withMinimap={false}
         />

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -62,7 +62,7 @@ export const App: Component = () => {
         if (error) return actions.set({ error });
         if (!compiled) return;
 
-        actions.set({ compiled, isCompiling: false });
+        actions.setCompiled(compiled);
 
         console.log('Compilation took:', formatMs(performance.now() - now));
         break;
@@ -277,7 +277,7 @@ export const App: Component = () => {
         }
       >
         <Editor
-          value={store.currentTab}
+          url={`file:///${store.currentTab.name}.${store.currentTab.type}`}
           onDocChange={handleDocChange}
           class="h-full max-h-screen overflow-auto flex-1 focus:outline-none whitespace-pre-line bg-blueGray-50 dark:bg-blueGray-800 row-start-3"
           styles={{ backgroundColor: '#F8FAFC' }}
@@ -300,12 +300,7 @@ export const App: Component = () => {
         <Show when={!showPreview()}>
           <section class="h-full max-h-screen bg-white dark:bg-blueGray-800 overflow-hidden flex flex-col flex-1 focus:outline-none row-start-5 md:row-start-3 relative divide-y-2 divide-blueGray-200 dark:divide-blueGray-500">
             <Editor
-              value={{
-                source: store.compiled.replace(/(https:\/\/cdn.skypack.dev\/)|(@[0-9.]+)/g, ''),
-                id: '',
-                name: 'output_dont_import',
-                type: 'tsx',
-              }}
+              url="file:///output_dont_import.tsx"
               class="h-full overflow-auto focus:outline-none flex-1"
               styles={{ backgroundColor: '#fff' }}
               isDark={store.dark}

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -47,3 +47,7 @@ div[contenteditable='true']:focus {
   height: 2px;
   @apply absolute w-full left-0 bottom-0 bg-blueGray-200 dark:bg-blueGray-700 z-0;
 }
+
+textarea.monaco-mouse-cursor-text:focus {
+  box-shadow: unset;
+}

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -16,15 +16,12 @@ import {
   checkCircle,
   clipboardCheck,
 } from '@amoutonbrady/solid-heroicons/outline';
-import { Tab } from '../../store';
 import './setupSolid';
 
 const Editor: Component<Props> = (props) => {
   let parent!: HTMLDivElement;
   let editor: mEditor.IStandaloneCodeEditor;
-  let model = createMemo(() =>
-    mEditor.getModel(Uri.parse(`file:///${props.value.name}.${props.value.type}`)),
-  );
+  let model = createMemo(() => mEditor.getModel(Uri.parse(props.url)));
 
   const [format, setFormat] = createSignal(false);
   function formatCode() {
@@ -152,7 +149,7 @@ const Editor: Component<Props> = (props) => {
 export default Editor;
 
 interface Props extends JSX.HTMLAttributes<HTMLDivElement> {
-  value: Tab;
+  url: string;
   disabled: boolean;
   styles: Record<string, string>;
   canCopy?: boolean;

--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -42,36 +42,37 @@ const Editor: Component<Props> = (props) => {
     });
   }
 
-  languages.registerDocumentFormattingEditProvider('typescript', {
-    provideDocumentFormattingEdits: async (model) => {
-      props.formatter.postMessage({
-        event: 'FORMAT',
-        code: model.getValue(),
-        pos: editor.getPosition(),
-      });
-      return new Promise((resolve, reject) => {
-        props.formatter.addEventListener(
-          'message',
-          ({ data }) => {
-            const { event, code } = data;
-            switch (event) {
-              case 'RESULT':
-                resolve([
-                  {
-                    range: model.getFullModelRange(),
-                    text: code,
-                  },
-                ]);
-                break;
-              default:
-                reject();
-            }
-          },
-          { once: true },
-        );
-      });
-    },
-  });
+  if (props.formatter) {
+    languages.registerDocumentFormattingEditProvider('typescript', {
+      provideDocumentFormattingEdits: async (model) => {
+        props.formatter.postMessage({
+          event: 'FORMAT',
+          code: model.getValue(),
+          pos: editor.getPosition(),
+        });
+        return new Promise((resolve, reject) => {
+          props.formatter.addEventListener(
+            'message',
+            ({ data: { event, code } }) => {
+              switch (event) {
+                case 'RESULT':
+                  resolve([
+                    {
+                      range: model.getFullModelRange(),
+                      text: code,
+                    },
+                  ]);
+                  break;
+                default:
+                  reject();
+              }
+            },
+            { once: true },
+          );
+        });
+      },
+    });
+  }
 
   // Initialize CodeMirror
   onMount(() => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -89,6 +89,12 @@ const [Store, useStore] = createStore({
       if (idx < 0) return;
       set({ current: current });
     },
+    setCompiled(compiled: string) {
+      editor
+        .getModel(Uri.parse(`file:///output_dont_import.tsx`))
+        .setValue(compiled.replace(/(https:\/\/cdn.skypack.dev\/)|(@[0-9.]+)/g, ''));
+      set({ compiled, isCompiling: false });
+    },
     setTabName(id: string, name: string) {
       // FIXME: Use the below function, at the moment TS is not content
       // ref: https://github.com/ryansolid/solid/blob/master/documentation/store.md#setpath-changes

--- a/src/workers/compiler.ts
+++ b/src/workers/compiler.ts
@@ -44,7 +44,7 @@ function virtual({ SOLID_VERSION, solidOptions = {} }) {
 
     async resolveId(importee: string) {
       // This is a tab being imported
-      if (importee.startsWith('.')) return importee + '.tsx';
+      if (importee.startsWith('.')) return importee.replace('.tsx', '') + '.tsx';
 
       // This is an external module
       return {


### PR DESCRIPTION
now the command palette (`F1`) also uses the prettier formatter, and I think I got rid of the flickering