### PR TITLE
enlarge column resizer for better usability

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -305,7 +305,7 @@ export const App: Component = () => {
         />
 
         <div
-          class="h-full w-full row-start-2 row-end-4 col-start-2 hidden md:block"
+          class="column-resizer h-full w-full row-start-2 row-end-4 col-start-2 hidden md:block"
           style="cursor: col-resize"
           onMouseDown={[setIsDragging, true]}
         >

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -28,6 +28,20 @@ div[contenteditable='true']:focus {
   grid-template-rows: auto auto minmax(0, 1fr) auto minmax(0, 1fr);
 }
 
+.column-resizer {
+  position: relative;
+  z-index: 100;
+}
+
+.column-resizer:hover::after {
+  position: absolute;
+  content: '';
+  top: 0;
+  left: -8px;
+  right: -8px;
+  height: 100%;
+}
+
 @screen md {
   .wrapper {
     --left: minmax(0, 1fr);

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -29,17 +29,12 @@ div[contenteditable='true']:focus {
 }
 
 .column-resizer {
-  position: relative;
-  z-index: 100;
+  @apply relative z-50;
 }
 
 .column-resizer:hover::after {
-  position: absolute;
   content: '';
-  top: 0;
-  left: -6px;
-  right: -6px;
-  height: 100%;
+  @apply absolute top-0 -left-6px -right-6px bg-brand-default h-full;
 }
 
 @screen md {

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -37,8 +37,8 @@ div[contenteditable='true']:focus {
   position: absolute;
   content: '';
   top: 0;
-  left: -8px;
-  right: -8px;
+  left: -6px;
+  right: -6px;
   height: 100%;
 }
 


### PR DESCRIPTION
Currently the column resizer, that resizes the split editor and code output is too small. It's 2px wide, this can be a little cumbersome for some users who are able to select it the first time.

![column-resize-small](https://user-images.githubusercontent.com/29286430/115447412-574d8d80-a1cd-11eb-95e6-1f2ff35438c6.gif)

This PR still keeps the original column-resizer size, but when hovered over, the element selection size is enlarged. This is done by adding CSS pseudo element. This is better than having a visually hidden padding, because you wouldn't be able to interact part of  editor's scrollbar. This gif example shows the enlarged element as red, ( when it is transparent in prod ). 

![column-resize-large](https://user-images.githubusercontent.com/29286430/115454939-2faef300-a1d6-11eb-82dc-7a7ad94869bb.gif)

The column-resizer when hovered is 12px of width.